### PR TITLE
add unidecode for normalization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,6 @@ idna==3.4
 multidict==6.0.4
 python-dotenv==1.0.0
 requests==2.30.0
+Unidecode==1.3.6
 urllib3==2.0.2
 yarl==1.9.2


### PR DESCRIPTION
now we can normalize text like this:

```py
from unidecode import unidecode

s = u"\u2018"
print(unidecode(s))
```